### PR TITLE
Use JS::MarkedVector in Plugin::Console::printer instead of AK::Vector

### DIFF
--- a/src/Cosmo.cpp
+++ b/src/Cosmo.cpp
@@ -40,7 +40,7 @@ public:
 JS::ThrowCompletionOr<JS::Value> Plugin::Console::printer(JS::Console::LogLevel log_level,
                                                           PrinterArguments printer_arguments)
 {
-    if (auto* values = printer_arguments.get_pointer<AK::Vector<JS::Value>>())
+    if (auto* values = printer_arguments.get_pointer<JS::MarkedVector<JS::Value>>())
     {
         auto output = String::join(" ", *values);
 


### PR DESCRIPTION
~~DO NOT MERGE UNTIL https://github.com/SerenityOS/serenity/pull/13939 HAS BEEN MERGED.~~
https://github.com/SerenityOS/serenity/pull/13939 has been merged.

The Console API provided by LibJS has been updated to vend a
JS::MarkedVector instead of an AK::Vector to ensure the stored values
are seen by GC and not suddenly deleted.