### PR TITLE
Correctly check the type of the `this` value in Game::on and Command::register_

### DIFF
--- a/src/Scripting/Game.cpp
+++ b/src/Scripting/Game.cpp
@@ -67,6 +67,12 @@ JS_DEFINE_NATIVE_FUNCTION(Game::mod_description_getter)
 
 JS_DEFINE_NATIVE_FUNCTION(Game::on)
 {
+    auto this_value = vm.this_value(global_object);
+    if (!this_value.is_object() || !is<Game>(this_value.as_object()))
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, "Game");
+
+    auto& game_object = static_cast<Game&>(this_value.as_object());
+
     auto event_name = vm.argument(0);
     if (!event_name.is_string())
         return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAString, event_name);
@@ -75,8 +81,7 @@ JS_DEFINE_NATIVE_FUNCTION(Game::on)
     if (!event_callback.is_function())
         return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAFunction, event_callback);
 
-    auto* this_value = verify_cast<Game>(TRY(vm.this_value(global_object).to_object(global_object)));
-    this_value->m_event_handlers
+    game_object.m_event_handlers
         .ensure(event_name.as_string().string(), [&vm]() { return JS::MarkedVector<JS::FunctionObject*>(vm.heap()); })
         .append(&event_callback.as_function());
 


### PR DESCRIPTION
Check if `this` is an object of type `Game` in Game::on

Previously, we assumed the `this` object was an object of type `Game`.
This would cause a crash if Game.on was, for example, called like so:
```js
Game.on.call(1)
```

This also moves retrieving the `this` value to the start of the
function, as the `this` value is the first argument to `call`.

-----

Check if `this` is an object of type `Command` in Command::register_

Previously, we assumed the `this` object was an object of type
`Command`. This would cause a crash if Command.register was,
for example, called like so:
```js
Game.Command.register.call(1)
```

This also moves retrieving the `this` value to the start of the
function, as the `this` value is the first argument to `call`.